### PR TITLE
feat: add 'run_experiments' task to 'run_campaign' DAG

### DIFF
--- a/src/airflow/dags/operators/run_experiments.py
+++ b/src/airflow/dags/operators/run_experiments.py
@@ -1,0 +1,66 @@
+from typing import Sequence
+
+from airflow.exceptions import AirflowException, AirflowFailException
+from airflow.operators.trigger_dagrun import TriggerDagRunOperator
+from airflow.utils.context import Context
+
+
+class RunExperiments(TriggerDagRunOperator):
+    """
+    Custom operator to run experiments.
+
+    This operator extends the TriggerDagRunOperator to trigger 'run_experiment' DAG in a loop.
+
+    Args:
+        experiment_ids (list[str]): List of experiment IDs to run.
+        allowed_failures (int | None): Number of failed experience runs allowed before the DAG is
+            marked as having failed. Defaults to None.
+        poke_interval (int): Interval (in seconds) between each poll while waiting for the
+            experiments to complete. Defaults to 60s.
+    """
+
+    template_fields: Sequence[str] = ("experiment_ids",)
+    __run_experiment_dag_id = "run_experiment"
+
+    def __init__(
+        self,
+        experiment_ids: list[str],
+        allowed_failures: int | None = None,
+        poke_interval: int = 60,
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            trigger_dag_id=self.__run_experiment_dag_id,
+            reset_dag_run=True,
+            wait_for_completion=True,
+            poke_interval=poke_interval,
+            allowed_states=["success"],
+            **kwargs,
+        )
+        self.experiment_ids = experiment_ids
+        self.allowed_failures = allowed_failures
+
+    def execute(self, context: Context):
+        """
+        Execute each of the experiments by successively triggering an execution of the
+        'run_experiment' DAG.
+
+        Args:
+            context (Context): The context passed by Airflow during task execution.
+        """
+        num_failures = 0
+        for index, experiment_id in enumerate(self.experiment_ids):
+            self.log.info(f"Running experiment {experiment_id}")
+            try:
+                self.conf = {
+                    "experiment_id": experiment_id,
+                    "destroy": True if index == len(self.experiment_ids) - 1 else False,
+                }
+                super().execute(context)
+            except AirflowException as error:
+                self.log.warning(f"An experiment run failed with error {error}.")
+                num_failures += 1
+                if self.allowed_failures is not None and num_failures >= self.allowed_failures:
+                    raise AirflowFailException(
+                        f"Stopped after {num_failures} unsuccessful experiment runs."
+                    )

--- a/src/airflow/dags/run_campaign.py
+++ b/src/airflow/dags/run_campaign.py
@@ -45,6 +45,8 @@ from airflow.decorators import dag, task
 from airflow.exceptions import AirflowFailException
 from airflow.models.param import Param
 
+from operators.run_experiments import RunExperiments
+
 
 data_dir = Path("/home/airflow/gcs/data")
 
@@ -89,7 +91,16 @@ def run_campaign():
         with (data_dir / f"campaigns/{campaign_id}").open() as f:
             return json.loads(f.read())["experiments"]
 
-    load_campaign()
+    load_campaign = load_campaign()
+
+    run_experiments = RunExperiments(
+        task_id="run_experiments",
+        experiment_ids=load_campaign["return_value"],
+        allowed_failures=0,
+        poke_interval=10,
+    )
+
+    load_campaign >> run_experiments
 
 
 run_campaign()


### PR DESCRIPTION
- feat: add 'load_experiment' task to 'run_experiment' DAG
- feat: add utility to generate gke kubeconfig
- feat: add 'update_kube_config' task to 'run_experiment DAG
- feat: add 'update_armonik_connection' to 'un_experiment' DAG
- feat: better implementation of 'run_client' task in 'run_experiment' DAG
- feat: add 'warm_up' task to 'run_experiment' DAG
- feat: add 'dump_data' and 'commit' tasks to 'run_experiment' DAG
- fix: client task option name for UUID
- feat: add 'run_campaign' DAG
- feat: add 'load_campaign' task to 'run_campaign' DAG
- feat: add 'run_experiments' task to 'run_campaign' DAG
